### PR TITLE
Fix json

### DIFF
--- a/data/cheese-viewport.json
+++ b/data/cheese-viewport.json
@@ -53,9 +53,9 @@
   "type": "ClutterActor",
   "children":
   [
-    'video_preview',
-    'countdown_layer',
-    'error_layer'
+    "video_preview",
+    "countdown_layer",
+    "error_layer"
   ]
 },
 {


### PR DESCRIPTION
to possibly avoid this error when starting cheese:

```
** (cheese:1640311): ERROR **: 10:38:02.902: cheese-window.vala:1322: Error: <data>:56:5: Parse error: unexpected character `'', expected character `]'
Trace/breakpoint trap (core dumped)
```

(the error seems to originate here: https://github.com/GNOME/cheese/blob/a7af33869a07534b294e093d788713459ba7a86d/src/cheese-window.vala#L1316-L1323)

I don't know why it happened now (the file hasn't been touched for 9 years :D) and I'm not even sure this fixed the error above. But the json is definitely invalid so it doesn't hurt to fix it :shrug: 